### PR TITLE
Refactor : DB재설계 - Product테이블 통합

### DIFF
--- a/backend/src/main/java/com/haedal/backend/product/model/Deposit.java
+++ b/backend/src/main/java/com/haedal/backend/product/model/Deposit.java
@@ -1,9 +1,11 @@
 package com.haedal.backend.product.model;
 
+import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
 //TODO : 상속 관련 설정
+@DiscriminatorValue("D")
 @Entity
 @Table(name = "Deposit")
 public class Deposit extends Product {

--- a/backend/src/main/java/com/haedal/backend/product/model/InstallmentSavings.java
+++ b/backend/src/main/java/com/haedal/backend/product/model/InstallmentSavings.java
@@ -1,10 +1,12 @@
 package com.haedal.backend.product.model;
 
 import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
 //TODO : 상속 관련 설정
+@DiscriminatorValue("I")
 @Entity
 @Table(name = "InstallmentSavings")
 public class InstallmentSavings extends Product {

--- a/backend/src/main/java/com/haedal/backend/product/model/Product.java
+++ b/backend/src/main/java/com/haedal/backend/product/model/Product.java
@@ -10,7 +10,9 @@ import java.util.List;
 @Getter
 @Table
 @Entity
-public class Product {
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE) //
+//@DisCriminatorColumn(name = "DTYPE") // 단일 테이블에서는 Dtype컬럼이 자동생성되므로 생략
+public abstract class Product {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
[Refactor]

DB는 상속을 지원하지 않으므로, 논리 모델을 물리 모델로 구현할 방법이 필요

-> Product테이블과 InstallmentSaving, Deposit 테이블을 통합하여, 데이터베이스상 단일테이블을 형성하였습니다
