### PR TITLE
refactor : 상품 상세 페이지와 상품 가입 페이지 분리, 찜 기능 추가

### DIFF
--- a/backend/src/main/java/com/haedal/backend/Dibs/controller/DibsController.java
+++ b/backend/src/main/java/com/haedal/backend/Dibs/controller/DibsController.java
@@ -58,4 +58,18 @@ public class DibsController {
         System.out.println("찜 취소");
         return ResponseEntity.ok("찜이 취소되었습니다.");
     }
+
+    //해당상품의 찜 여부를 확인
+    @GetMapping("/{productId}/check")
+    public ResponseEntity<Boolean> checkDibs(Authentication authentication, @PathVariable Long productId) {
+        String id = authentication.getName();
+        User user = profileService.findById(id);
+
+        // 해당 사용자의 productId에 대한 찜 여부를 확인합니다.
+        Dibs dibs = dibsService.findDibsByUserIDProductID(user.getUserId(), productId);
+
+        // 찜 여부를 클라이언트에게 전달합니다.
+        boolean isDibs = (dibs != null);
+        return ResponseEntity.ok(isDibs);
+    }
 }

--- a/backend/src/main/java/com/haedal/backend/product/controller/RecommendedProductController.java
+++ b/backend/src/main/java/com/haedal/backend/product/controller/RecommendedProductController.java
@@ -77,19 +77,25 @@ public class RecommendedProductController {
 
         // 상위 3개의 상품을 선택
 //        int maxRankingCount = Math.max(sortedAssets.size(), 3);
-        for (int i = 0; i < 3; i++) {
-            if (sellProducts.isEmpty() == false) {
+        if (sellProducts.size()>=3) {
+            for (int i = 0; i < 3 ; i++) {
                 Product product = sellProducts.get(i);
                 rankingAssets.add(product);
-                // 예외처리1 : 추천상품이 없는 경우
-            } else {
-                System.out.println("추천상품이 없습니다");
             }
+        } else if(sellProducts.size()<3) {
+            for (int i = 0;  i < sellProducts.size(); i++) {
+                Product product = sellProducts.get(i);
+                rankingAssets.add(product);
+            }
+        }
+        else if(sellProducts.size()==0) {
+            System.out.println("추천상품이 없습니다");
+        }
 
-            productResponses = rankingAssets.stream()
+        productResponses = rankingAssets.stream()
                     .map(ProductResponse::recommendedFrom)
                     .collect(Collectors.toList());
-        }
+
 
         return productResponses;
     }
@@ -112,6 +118,7 @@ public class RecommendedProductController {
 
         //status가 true인 것들만 저장
         List<Product> sellProducts = new ArrayList<>();
+
         for(int i =0;i<sortedServicePurpose.size();i++){
             if(sortedServicePurpose.get(i).getProductStatus()== true){
                 sellProducts.add(sortedServicePurpose.get(i));

--- a/backend/src/main/java/com/haedal/backend/product/dto/response/ProductResponse.java
+++ b/backend/src/main/java/com/haedal/backend/product/dto/response/ProductResponse.java
@@ -44,6 +44,8 @@ public class ProductResponse {
 
     private String accountNumber; //유저 계좌번호를 넘겨주기 위함
 
+    //사용자 계좌 잔액
+    private Long asset;
 
     public static ProductResponse from(Product product)  {
         return ProductResponse.builder()
@@ -91,7 +93,7 @@ public class ProductResponse {
             .maxProductMoney(foundProduct.getMaxProductMoney())
             .isDeposit(foundProduct.isDeposit())
             .subscription(foundProduct.getSubscription())
-            .accountNumber(user.getAccountNumber())
+            .accountNumber(user.getAccountNumber()).asset(user.getAsset())
             .build();
         return productResponse;
     }

--- a/backend/src/main/java/com/haedal/backend/subscribe/controller/SubscribeController.java
+++ b/backend/src/main/java/com/haedal/backend/subscribe/controller/SubscribeController.java
@@ -35,22 +35,33 @@ public class SubscribeController {
 
     //신청 상품 정보 표출
     @GetMapping("/{productId}")
-    public ProductResponse showSubcribeProduct(Authentication authentication, @PathVariable(name = "productId") Long productId){
-        String id = authentication.getName();
-        User user = profileService.findById(id);
-
+    public ProductResponse showSubscribeProduct( @PathVariable(name = "productId") Long productId){
         Product foundProduct = productService.findByProductId(productId);
         System.out.println(productId + "정보 조회");
 
-        ProductResponse productResponse = ProductResponse.mapProductToResponse(foundProduct,user);
+        ProductResponse productResponse = ProductResponse.from(foundProduct);
 
         System.out.println(productResponse);
         return productResponse;
     }
 
+    //유저와 상품 페이지 정보 표출
+    @GetMapping("/{productId}/semi")
+    public ProductResponse showSubscribeProductAndUser(Authentication authentication, @PathVariable(name = "productId") Long productId) {
+        String id = authentication.getName();
+        User user = profileService.findById(id);
+
+        Product foundProduct = productService.findByProductId(productId);
+        System.out.println(productId + "신청 페이지");
+
+        ProductResponse productResponse = ProductResponse.mapProductToResponse(foundProduct, user);
+
+        System.out.println(productResponse);
+        return productResponse;
+    }
 
     //상품 신청 페이지 '신청'버튼 클릭
-    @PostMapping("/{productId}/*")
+    @PostMapping("/{productId}/final")
     public ResponseEntity<String> subscribeproduct(Authentication authentication , @PathVariable Long productId, @RequestBody Map<String, String> requestData){
         //인증에 맞춰 정보 수정
         String id = authentication.getName();

--- a/frontend/src/layouts/default/Footer.vue
+++ b/frontend/src/layouts/default/Footer.vue
@@ -1,19 +1,15 @@
 <template>
-  <v-footer flat 
-    class="bg-indigo-lighten-1 text-center d-flex flex-column"
-  >
+  <v-footer flat class="bg-blue-lighten-1 text-center d-flex flex-column">
     <div>
-      <v-btn
-        v-for="icon in icons"
-        :key="icon"
-        class="mx-4"
-        :icon="icon"
-        variant="text"
-      ></v-btn>
+      <v-btn v-for="icon in icons" :key="icon" class="mx-4" :icon="icon" variant="text"></v-btn>
     </div>
 
     <div class="pt-0">
-      Phasellus feugiat arcu sapien, et iaculis ipsum elementum sit amet. Mauris cursus commodo interdum. Praesent ut risus eget metus luctus accumsan id ultrices nunc. Sed at orci sed massa consectetur dignissim a sit amet dui. Duis commodo vitae velit et faucibus. Morbi vehicula lacinia malesuada. Nulla placerat augue vel ipsum ultrices, cursus iaculis dui sollicitudin. Vestibulum eu ipsum vel diam elementum tempor vel ut orci. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+      Phasellus feugiat arcu sapien, et iaculis ipsum elementum sit amet. Mauris cursus commodo interdum. Praesent ut
+      risus eget metus luctus accumsan id ultrices nunc. Sed at orci sed massa consectetur dignissim a sit amet dui. Duis
+      commodo vitae velit et faucibus. Morbi vehicula lacinia malesuada. Nulla placerat augue vel ipsum ultrices, cursus
+      iaculis dui sollicitudin. Vestibulum eu ipsum vel diam elementum tempor vel ut orci. Orci varius natoque penatibus
+      et magnis dis parturient montes, nascetur ridiculus mus.
     </div>
 
     <v-divider></v-divider>
@@ -35,6 +31,4 @@ const icons = ref([
   'mdi-instagram',
 ]);
 </script>
-<style>
-
-</style>
+<style></style>

--- a/frontend/src/layouts/default/Footer.vue
+++ b/frontend/src/layouts/default/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-footer flat class="bg-blue-lighten-1 text-center d-flex flex-column">
+  <v-footer flat class="bg-blue-lighten-3 text-center d-flex flex-column">
     <div>
       <v-btn v-for="icon in icons" :key="icon" class="mx-4" :icon="icon" variant="text"></v-btn>
     </div>

--- a/frontend/src/views/Error.vue
+++ b/frontend/src/views/Error.vue
@@ -57,6 +57,7 @@ p {
     height: 500px;
     margin: auto;
     margin-top: 5%;
+    margin-bottom: 5%;
     color: rgb(0, 63, 90);
     border-radius: 30px;
     vertical-align: middle !important;

--- a/frontend/src/views/MainPage.vue
+++ b/frontend/src/views/MainPage.vue
@@ -23,10 +23,9 @@
           </span>
           <div class="text-caption">{{ recommend.shortInfo }}</div>
         </div>
-        <v-btn
+        <v-btn @click="detail(recommend)"
           style="background: rgba(0, 179, 255, 0.826); color:white; font-weight: bold; border-radius: 15px; width:200px;height: 40px;">추천
           상품 정보 보기</v-btn>
-        <!--TODO : 상품 상세 정보 조회 페이지 제작-->
       </div>
     </v-card>
 
@@ -39,7 +38,8 @@
     <div style=" margin:auto; display: flex; justify-content: center;;">
       <img src='@/assets/img/main-image1.png' class="first-image">
     </div>
-    <p style="margin-top:100px; font-size: 18px; color:balck; font-weight: 500;">해달이 추천해드리는 여러분에게 딱 맞는 상품을 만나보세요.</p>
+    <p style="margin-top:100px; font-size: 18px; color:balck; font-weight: 500;">해달이 추천해드리는 여러분에게 딱 맞는 상품을 만나보세요.
+    </p>
     <p style="margin-top:150px; color:rgba(0, 179, 255, 0.826);">지금 시작해 보세요!</p>
     <v-btn
       style="background: rgba(0, 179, 255, 0.826); color:white; font-weight: bold; border-radius: 30px; margin-bottom: 1rem; margin-top:70px; width:400px;height: 60px;"
@@ -105,6 +105,29 @@ onMounted(() => {
   }, 60000) // 1분마다 체크 (조절 가능)
 })
 
+//추천 상품 상세 정보 보기 버튼
+const detail = (item) => {
+  const productId = item.productId;
+  const productName = item.productName
+  console.log(productName);
+  console.log(item.deposit);
+  if (item.deposit == true) {
+    router.push(
+      {
+        name: 'subscribeD',
+        params: {
+          id: productId,
+        }
+      })
+  } else if (item.deposit == false) {
+    router.push({
+      name: 'subscribeI',
+      params: {
+        id: productId,
+      }
+    })
+  }
+}
 </script>
 
 <style>

--- a/frontend/src/views/ProductList.vue
+++ b/frontend/src/views/ProductList.vue
@@ -56,10 +56,12 @@
                     정보 보기
                 </v-btn>
             </v-card-actions>
-            <span class="favorite" @click="dibs(item.productId)" style="cursor:pointer;">
-                <img v-if="dibed === true" src='@/assets/img/favorite.png'>
+
+            <span class="favorite" @click="dibs(item)" style="cursor:pointer;">
+                <img v-if="item.isDibs === true" src='@/assets/img/favorite.png'>
                 <img v-else src='@/assets/img/favorite_border.png'>
             </span>
+
         </v-card>
     </div>
 </template>
@@ -69,6 +71,7 @@ import axios from 'axios'
 import { watchEffect, ref } from 'vue'
 import router from '../router'
 import { mdiConsoleNetwork } from '@mdi/js';
+import { useAuthStore } from '@/store/app';
 
 // 서버에서 받아오는 정보
 const listData = ref([]);
@@ -80,7 +83,9 @@ const searchTerm = ref('');
 const showNoDataMessage = ref(false);
 
 //찜 해두었는지 여부
-const dibed = ref(false);
+const isDibs = ref(false);
+
+const authStore = useAuthStore();
 
 // Axios 인스턴스 생성
 const axiosInstance = axios.create({
@@ -93,19 +98,69 @@ watchEffect(() => {
     axiosInstance.get('/products').then((res) => {
         showNoDataMessage.value = false;
 
-        let tempArr = [...res.data]
+        let tempArr = [...res.data];
         tempArr.forEach((item) => {
-            console.log(item)
-            listData.value.push(item)
-        })
+            console.log(item);
+            // 데이터를 받아온 후에 listData에 추가
+            listData.value.push(item);
+        });
+
+        // 모든 데이터를 받아온 후에 찜 여부를 확인
+        listData.value.forEach((item) => {
+            axiosInstance.get(`/dibs/${item.productId}/check`, {
+                headers: {
+                    Authorization: `Bearer ${authStore.accessToken}`
+                }
+            }).then((res) => {
+                item.isDibs = res.data; // 상품 객체에 찜 여부 추가
+                console.log(item.isDibs);
+            }).catch((error) => {
+                // 로그인 되어 있지 않을 시 무조건 false
+                item.isDibs = false;
+            });
+        });
         console.log(listData);
-    })
-})
+    });
+});
+
+
+// 찜하기 버튼 누를 시
+const dibs = (item) => {
+    if (!item.isDibs) {
+        console.log("찜!");
+        axios({
+            method: "post",
+            url: `http://localhost:8080/dibs/${item.productId}/add`,
+            headers: {
+                Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+            },
+        })
+            .then(() => {
+                item.isDibs = true; // Vue 3에서는 ref를 사용하므로 .value 없이 값 변경
+            })
+            .catch((error) => alert("로그인 후 이용 가능한 서비스 입니다"));
+    } else {
+        console.log("찜 취소");
+        axios({
+            method: "delete",
+            url: `http://localhost:8080/dibs/${item.productId}/delete`,
+            headers: {
+                Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+            },
+        })
+            .then(() => {
+                item.isDibs = false; // Vue 3에서는 ref를 사용하므로 .value 없이 값 변경
+            })
+            .catch((error) => alert("로그인 후 이용 가능한 서비스 입니다"));
+    }
+}
+
+
 
 //검색 기능
 const searchForm = () => {
-    //listData 초기화
-    listData.value = [];
+    //기존 데이터 제거
+    listData.value.splice(0, listData.value.length);
 
     showNoDataMessage.value = false;
 
@@ -190,31 +245,6 @@ const tema = () => {
     })
 }
 
-
-// 
-const dibs = (productId) => {
-    if (dibed.value === false) {
-        console.log("찜!")
-        axios({
-            method: "post",
-            url: `http://localhost:8080/dibs/${productId}/add`,
-            headers: {
-                Authorization: `Bearer ${localStorage.getItem('accessToken')}`, // 토큰 포함
-            },
-        })
-        dibed.value = true;
-    } else if (dibed.value === true) {
-        console.log("찜 취소")
-        axios({
-            method: "delete",
-            url: `http://localhost:8080/dibs/${productId}/delete`,
-            headers: {
-                Authorization: `Bearer ${localStorage.getItem('accessToken')}`, // 토큰 포함
-            },
-        })
-        dibed.value = false;
-    }
-}
 </script>
 
 

--- a/frontend/src/views/ProductList.vue
+++ b/frontend/src/views/ProductList.vue
@@ -53,7 +53,7 @@
 
                 <v-btn style="background: rgba(0, 179, 255, 0.826); color:white; font-weight: bold; border-radius: 0.6rem;"
                     @click=subscribeProduct(item)>
-                    가입 하기
+                    정보 보기
                 </v-btn>
             </v-card-actions>
             <span class="favorite" @click="dibs(item.productId)" style="cursor:pointer;">
@@ -126,7 +126,7 @@ const searchForm = () => {
     })
 }
 
-//가입하기 버튼
+//상품 정보 버튼
 const subscribeProduct = (item) => {
     const productId = item.productId;
     const productName = item.productName

--- a/frontend/src/views/RecommendedProduct.vue
+++ b/frontend/src/views/RecommendedProduct.vue
@@ -48,6 +48,10 @@
                     </div>
                 </v-card-item>
                 <div class="d-flex justify-end align-center">
+                    <span class="favorite" @click="dibs(item)" style="cursor:pointer;">
+                        <img v-if="item.isDibs === true" src='@/assets/img/favorite.png'>
+                        <img v-else src='@/assets/img/favorite_border.png'>
+                    </span>
                     <v-card-actions>
                         <v-btn class="button-style" @click=subscribeProduct(item)>
                             가입 하기
@@ -92,11 +96,59 @@ watchEffect(() => {
             console.log(item)
             listData.value.push(item)
         })
+
+
+        // 모든 데이터를 받아온 후에 찜 여부를 확인
+        listData.value.forEach((item) => {
+            axiosInstance.get(`/dibs/${item.productId}/check`, {
+                headers: {
+                    Authorization: `Bearer ${authStore.accessToken}`
+                }
+            }).then((res) => {
+                item.isDibs = res.data; // 상품 객체에 찜 여부 추가
+                console.log(item.isDibs);
+            }).catch((error) => {
+                // 로그인 되어 있지 않을 시 무조건 false
+                item.isDibs = false;
+            });
+        });
         console.log(listData);
     }).catch((error) => {
-        router.push('/error');
+        // router.push('/error');
     })
 })
+
+// 찜하기 버튼 누를 시
+const dibs = (item) => {
+    if (!item.isDibs) {
+        console.log("찜!");
+        axios({
+            method: "post",
+            url: `http://localhost:8080/dibs/${item.productId}/add`,
+            headers: {
+                Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+            },
+        })
+            .then(() => {
+                item.isDibs = true; // Vue 3에서는 ref를 사용하므로 .value 없이 값 변경
+            })
+            .catch((error) => alert("로그인 후 이용 가능한 서비스 입니다"));
+    } else {
+        console.log("찜 취소");
+        axios({
+            method: "delete",
+            url: `http://localhost:8080/dibs/${item.productId}/delete`,
+            headers: {
+                Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+            },
+        })
+            .then(() => {
+                item.isDibs = false; // Vue 3에서는 ref를 사용하므로 .value 없이 값 변경
+            })
+            .catch((error) => alert("로그인 후 이용 가능한 서비스 입니다"));
+    }
+}
+
 
 //연령대 해당 상품 버튼
 const ageGroup = () => {
@@ -246,5 +298,16 @@ p {
     margin-top: 14px;
     font-weight: bolder;
     font-size: 18px;
+}
+
+.favorite {
+    width: 10px;
+    margin: auto;
+}
+
+.favorite img {
+    width: 25px;
+    height: 25px;
+    object-fit: cover;
 }
 </style>

--- a/frontend/src/views/RecommendedProduct.vue
+++ b/frontend/src/views/RecommendedProduct.vue
@@ -93,7 +93,9 @@ watchEffect(() => {
             listData.value.push(item)
         })
         console.log(listData);
-    }).catch(router.push('/error'));
+    }).catch((error) => {
+        router.push('/error');
+    })
 })
 
 //연령대 해당 상품 버튼

--- a/frontend/src/views/RecommendedProduct.vue
+++ b/frontend/src/views/RecommendedProduct.vue
@@ -48,12 +48,12 @@
                     </div>
                 </v-card-item>
                 <div class="d-flex justify-end align-center">
-                    <span class="favorite" @click="dibs(item)" style="cursor:pointer;">
+                    <span class="favorite" @click="dibs(item)" style="cursor:pointer;margin-right: 10px;">
                         <img v-if="item.isDibs === true" src='@/assets/img/favorite.png'>
                         <img v-else src='@/assets/img/favorite_border.png'>
                     </span>
-                    <v-card-actions>
-                        <v-btn class="button-style" @click=subscribeProduct(item)>
+                    <v-card-actions style="margin-left: 1rem;">
+                        <v-btn class=" button-style" @click=subscribeProduct(item)>
                             정보 보기
                         </v-btn>
                     </v-card-actions>
@@ -77,7 +77,6 @@ import { useAuthStore } from '@/store/app';
 // 서버에서 받아오는 정보
 const listData = ref([]);
 const authStore = useAuthStore();
-
 
 // Axios 인스턴스 생성
 const axiosInstance = axios.create({
@@ -337,7 +336,6 @@ p {
     box-shadow: none;
     background: rgba(0, 179, 255, 0.826);
     color: white;
-    margin-top: 14px;
     font-weight: bolder;
     font-size: 18px;
 }

--- a/frontend/src/views/RecommendedProduct.vue
+++ b/frontend/src/views/RecommendedProduct.vue
@@ -54,7 +54,7 @@
                     </span>
                     <v-card-actions>
                         <v-btn class="button-style" @click=subscribeProduct(item)>
-                            가입 하기
+                            정보 보기
                         </v-btn>
                     </v-card-actions>
                 </div>
@@ -78,6 +78,7 @@ import { useAuthStore } from '@/store/app';
 const listData = ref([]);
 const authStore = useAuthStore();
 
+
 // Axios 인스턴스 생성
 const axiosInstance = axios.create({
     baseURL: 'http://localhost:8080',
@@ -96,7 +97,6 @@ watchEffect(() => {
             console.log(item)
             listData.value.push(item)
         })
-
 
         // 모든 데이터를 받아온 후에 찜 여부를 확인
         listData.value.forEach((item) => {
@@ -163,6 +163,20 @@ const ageGroup = () => {
             console.log(item)
             listData.value.push(item)
         })
+
+        listData.value.forEach((item) => {
+            axiosInstance.get(`/dibs/${item.productId}/check`, {
+                headers: {
+                    Authorization: `Bearer ${authStore.accessToken}`
+                }
+            }).then((res) => {
+                item.isDibs = res.data; // 상품 객체에 찜 여부 추가
+                console.log(item.isDibs);
+            }).catch((error) => {
+                // 로그인 되어 있지 않을 시 무조건 false
+                item.isDibs = false;
+            });
+        });
         console.log(listData);
     })
 }
@@ -180,6 +194,20 @@ const purpose = () => {
             console.log(item)
             listData.value.push(item)
         })
+
+        listData.value.forEach((item) => {
+            axiosInstance.get(`/dibs/${item.productId}/check`, {
+                headers: {
+                    Authorization: `Bearer ${authStore.accessToken}`
+                }
+            }).then((res) => {
+                item.isDibs = res.data; // 상품 객체에 찜 여부 추가
+                console.log(item.isDibs);
+            }).catch((error) => {
+                // 로그인 되어 있지 않을 시 무조건 false
+                item.isDibs = false;
+            });
+        });
         console.log(listData);
     })
 }
@@ -197,6 +225,20 @@ const asset = () => {
             console.log(item)
             listData.value.push(item)
         })
+
+        listData.value.forEach((item) => {
+            axiosInstance.get(`/dibs/${item.productId}/check`, {
+                headers: {
+                    Authorization: `Bearer ${authStore.accessToken}`
+                }
+            }).then((res) => {
+                item.isDibs = res.data; // 상품 객체에 찜 여부 추가
+                console.log(item.isDibs);
+            }).catch((error) => {
+                // 로그인 되어 있지 않을 시 무조건 false
+                item.isDibs = false;
+            });
+        });
         console.log(listData)
     })
 }

--- a/frontend/src/views/RecommendedProduct.vue
+++ b/frontend/src/views/RecommendedProduct.vue
@@ -93,7 +93,7 @@ watchEffect(() => {
             listData.value.push(item)
         })
         console.log(listData);
-    })
+    }).catch(router.push('/error'));
 })
 
 //연령대 해당 상품 버튼

--- a/frontend/src/views/SubscribeD.vue
+++ b/frontend/src/views/SubscribeD.vue
@@ -205,7 +205,7 @@ div {
 }
 
 .button-style {
-    width: 25rem;
+    width: 20rem;
     border-radius: 10px;
     box-shadow: none;
     background: rgba(0, 179, 255, 0.826);
@@ -229,6 +229,7 @@ div {
 
 .datas {
     font-size: 14px;
+    margin-bottom: 200px
 }
 
 h2 {

--- a/frontend/src/views/SubscribeI.vue
+++ b/frontend/src/views/SubscribeI.vue
@@ -239,6 +239,7 @@ div {
 
 .datas {
     font-size: 14px;
+    margin-bottom: 200px;
 }
 
 h2 {

--- a/frontend/src/views/SubscribeI.vue
+++ b/frontend/src/views/SubscribeI.vue
@@ -3,7 +3,7 @@
     </div>
     <div class=submitForm>
         <form @submit.prevent="submitForm">
-            <h2>{{ listData.productName }} 상품 신청</h2><br class=".mb-8">
+            <h2>{{ listData.productName }} 상품 정보</h2><br class=".mb-8">
             <div class=datas>
                 <div style="margin-bottom:4rem">
                     <b>상품 설명</b><br>
@@ -27,26 +27,16 @@
                     {{ listData.period }} 개월
                 </div>
                 <br>
-                <div>
-                    <b>출금 계좌번호</b>
-                    {{ listData.accountNumber }}
-                </div>
-                <div>
-                    <b><label for="authenticationNumber">인증 번호</label></b>
-                    <input type="text" id="authenticationNumber" v-model="formData.authenticationNumber" required>
-                </div>
-                <div>
-                    <b><label for="startMoney">시작 구독료</label></b>
-                    <input type="number" id="startMoney" v-model="formData.startMoney" required>
-                </div>
-                <!-- <div>
-                    월 간 구독료 : {{ listData.subscription }} 원
-                </div> -->
+
                 <div style="margin: 2rem;">
+                    <div>
+                        <b><label for="startMoney">시작 구독료</label></b>
+                        <input type="number" id="startMoney" v-model="startMoney">
+                    </div>
                     <p style="font-size: 12px;font-weight: 300; margin-bottom: 0;">입력한 시작금액을 바탕으로</p>
                     <v-btn
                         style=" font-size: 18px; font-weight: 600; color: rgb(0, 162, 255); padding: 0.4rem 2rem; margin-bottom: 1rem; box-shadow: -2px 4px 10px 0px rgba(0, 0, 0, 0.066) ;"
-                        @click="calculate(formData.startMoney)" type="button">만기시 금액 예상하기
+                        @click="calculate" type="button">만기시 금액 예상하기
                     </v-btn>
                     <p
                         v-show="calculatedAmount !== null && calculatedAmount !== 0 && calculatedAmount <= listData.maxProductMoney">
@@ -55,9 +45,43 @@
                     </p>
                     <p v-show="calculatedAmount > listData.maxProductMoney">입력하신 금액이 최대 금액을 초과하였습니다.</p>
                 </div>
-                <v-btn class="button-style" variant="outlined" type="submit">
+                <v-btn class="button-style" variant="outlined" @click="openModal" type="button">
                     신청하기
                 </v-btn>
+
+                <!-- 모달 창 -->
+                <div v-if="showModal" class="blur-background" @click="closeModal"></div>
+                <div v-if="showModal" class="modal">
+                    <!-- 모달 내용: 계좌번호와 인증 번호 입력 -->
+                    <div class="modal-content">
+                        <h2>{{ listData.productName }} 상품 가입</h2>
+
+                        <div>
+                            <b>출금 계좌번호</b>
+                            {{ listData.accountNumber }}
+                        </div>
+                        <div>
+                            <b>계좌 잔액</b>
+                            {{ listData.asset }}
+                        </div>
+                        <div>
+                            <b>인증 번호</b>
+                            <input type="text" id="authenticationNumber" v-model="formData.authenticationNumber" required>
+                        </div>
+                        <div>
+                            <b><label for="startMoney">시작 구독료</label></b>
+                            <input type="number" id="startMoney" v-model="formData.startMoney" required>
+                        </div>
+                        <div style="margin-bottom:13px">
+                            <b>상품 가입 가능 금액</b><br>
+                            최소 {{ listData.requiredStartMoney }} 원 ~최대{{ listData.maxProductMoney }} 원
+                        </div>
+                        <v-btn class="button-style" variant="outlined" type="submit">
+                            신청하기
+                        </v-btn>
+                        <v-btn class="button-style" @click="closeModal">취소</v-btn>
+                    </div>
+                </div>
             </div>
         </form>
     </div>
@@ -76,25 +100,40 @@ const axiosInstance = axios.create({
     // baseURL: 'http://15.164.189.153:8080',
 })
 
+const route = useRoute();
+const productId = route.params.id;
+const currentPath = `/subscribe/${productId}`;
 const authStore = useAuthStore();
 const listData = ref({});
 
 const calculatedAmount = ref(null);
-
-const route = useRoute();
-const productId = route.params.id;
-const currentPath = `/subscribe/${productId}`;
+const showModal = ref(false);
 
 watchEffect(() => {
-    axiosInstance.get(`${currentPath}`, {
-        headers: {
-            Authorization: `Bearer ${authStore.accessToken}`
-        }
-    }).then((res) => {
+    axiosInstance.get(`${currentPath}`).then((res) => {
         console.log(res.data)
         listData.value = res.data
     })
 })
+
+const openModal = () => {
+    showModal.value = true;
+    axiosInstance.get(`${currentPath}/semi`, {
+        headers: {
+            Authorization: `Bearer ${authStore.accessToken}`
+        }
+    }).then((res) => {
+        console.log(res);
+        listData.value = res.data;
+    }).catch((error) => {
+        router.push('/error');
+    })
+};
+
+const closeModal = () => {
+    showModal.value = false;
+};
+
 
 console.log(listData);
 
@@ -103,7 +142,8 @@ const formData = {
     startMoney: ''
 };
 
-const calculate = (money) => {
+const calculate = () => {
+    const money = parseFloat(startMoney.value);
     if (money) {
         let totalAmount = 0;
         const n = listData.value.period;
@@ -114,12 +154,12 @@ const calculate = (money) => {
 
         calculatedAmount.value = parseFloat(totalAmount).toFixed(2);
     } else {
-        calculatedAmount.value = 오류;
+        console.log("오류");
     }
 };
 
 const submitForm = () => {
-    const url = `http://15.164.189.153:8080/subscribe/${productId}/I`;
+    const url = `http://15.164.189.153:8080/subscribe/${productId}/final`;
 
     // productId가 유효한 경우에만 요청을 보냅니다.
     axios.post(url, formData,
@@ -137,6 +177,7 @@ const submitForm = () => {
             console.error('에러 발생', error);
             alert("정보가 올바르지 않습니다.");
         });
+    closeModal(); // 모달 창 닫기
 };
 
 </script>
@@ -164,7 +205,7 @@ div {
 }
 
 .button-style {
-    width: 25rem;
+    width: 20rem;
     border-radius: 10px;
     box-shadow: none;
     background: rgba(0, 179, 255, 0.826);
@@ -174,6 +215,16 @@ div {
     font-size: 18px;
 }
 
+.modal-content .button-style {
+    width: 10rem;
+    border-radius: 10px;
+    box-shadow: none;
+    background: rgba(0, 179, 255, 0.826);
+    color: white;
+    margin: 14px 5px 0px 5px;
+    font-weight: bolder;
+    font-size: 18px;
+}
 
 .datas b {
     color: rgba(0, 0, 0, 0.712);
@@ -197,6 +248,37 @@ h2 {
 
 form {
     margin-bottom: 10rem;
+}
+
+/* 모달 스타일 */
+.modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 9999;
+    background-color: white;
+    border-radius: 10px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+    padding: 3rem;
+    max-width: 80%;
+    width: 450px;
+    overflow: hidden;
+}
+
+/* 블러 효과 스타일 */
+.blur-background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 145, 255, 0.2);
+    /* 블러 색상 및 투명도 설정 */
+    backdrop-filter: blur(5px);
+    /* 블러 효과 설정 */
+    z-index: 9998;
+    /* 모달 아래에 위치하도록 설정 */
 }
 </style>
   


### PR DESCRIPTION
### 상품 상세 페이지, 신청 페이지 분리
 - 상세내용 api 수정
 - 상품 신청페이지 api 추가
 - 프론트 상품 신청페이지 수정, 모달창 추가
 - 버튼명 '신청하기' -> '정보 보기'로 변경

### 찜 기능
- 상품 상세페이지 요청시 찜 정보 요청 api 추가
- 인증 여부에 따라 위의 api 분기 처리
- 찜함에 따라 ui 실시간 반영