### PR TITLE
refactor : 자산별 상품 추천 기준 추가

### DIFF
--- a/backend/src/main/java/com/haedal/backend/product/controller/RecommendedProductController.java
+++ b/backend/src/main/java/com/haedal/backend/product/controller/RecommendedProductController.java
@@ -64,10 +64,13 @@ public class RecommendedProductController {
         // filterByAsset() : ProductRepository에서 선언한 JPQL 쿼리가 담겨있음
         List<Product> sortedAssets = recommendedProductService.orderByAsset(productsIdsInAsset);
 
+        //상품 중 금리가 높은 것으로 정렬
+        List<Product> highInterests = recommendedProductService.orderByInterestRate(sortedAssets); //service단에서만 정렬
+
         //status가 true인 것들만 저장
         List<Product> sellProducts = new ArrayList<>();
-        for(int i =0;i<sortedAssets.size();i++){
-            if(sortedAssets.get(i).getProductStatus()== true){
+        for(int i =0;i<highInterests.size();i++){
+            if(highInterests.get(i).getProductStatus()== true){
                 sellProducts.add(sortedAssets.get(i));
             }
         }
@@ -207,7 +210,6 @@ public class RecommendedProductController {
 
         // 인기 순위 상위 3개의 상품 저장
         List<Product> rankingServicePurpose = new ArrayList<>();
-
         if (sellProducts.size()>=3) {
             for (int i = 0; i < 3 ; i++) {
                 Product product = sellProducts.get(i);

--- a/backend/src/main/java/com/haedal/backend/product/repository/ProductRepository.java
+++ b/backend/src/main/java/com/haedal/backend/product/repository/ProductRepository.java
@@ -70,4 +70,5 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "GROUP BY p.productId " +
             "ORDER BY COUNT(s) DESC")
     List<Product> orderByUserAgeGroup(@Param("productIdsInUserAgeGroup") List<Long> productIdsInUserAgeGroup);
+
 }

--- a/backend/src/main/java/com/haedal/backend/product/service/RecommendedProductService.java
+++ b/backend/src/main/java/com/haedal/backend/product/service/RecommendedProductService.java
@@ -28,4 +28,6 @@ public interface RecommendedProductService extends CrudService<Product, Long> {
 
     List<Product> orderByUserAgeGroup(List<Long> recommendedProductsIdsByUserAgeGroup);
 
+    List<Product> orderByInterestRate(List<Product> products);
+
 }

--- a/backend/src/main/java/com/haedal/backend/product/service/RecommendedProductServiceImpl.java
+++ b/backend/src/main/java/com/haedal/backend/product/service/RecommendedProductServiceImpl.java
@@ -14,7 +14,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Service
@@ -154,6 +156,13 @@ public class RecommendedProductServiceImpl implements RecommendedProductService 
         return productRepository.orderByUserAgeGroup(productIdsInUserAgeGroup);
     }
 
+    public List<Product> orderByInterestRate(List<Product> products) {
+        // 금리기준 내림차순 정렬
+        List<Product> sortedProducts = products.stream()
+                .sorted(Comparator.comparing(Product::getInterestRate).reversed())
+                .collect(Collectors.toList());
+        return sortedProducts;
+    }
 
     // TODO: Subscribe 테이블에서 productId에 해당하는 구독자 수를 조회하여 반환
 


### PR DESCRIPTION
자산별 추천의 기존 기준(사용자 자산보다 상품 가격이 낮은 경우)에서 기준을 추가.
사용자 자산보다 상품 가격이 낮으면서 , 금리가 높은 순서로 리스트를 정렬하여 이 안에서 구독자수를 기준으로 TOP 3의 상품을 추천합니다.

## DONE
- controller 수정
- service, service imp 추가