### PR TITLE
bug : authentication 테스트코드에서 사용시 null으로 전달되는 오류 수정

### DIFF
--- a/backend/src/main/java/com/haedal/backend/auth/controller/UserController.java
+++ b/backend/src/main/java/com/haedal/backend/auth/controller/UserController.java
@@ -31,6 +31,8 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Optional;
 
+
+@Slf4j
 @RestController
 @CrossOrigin("http://localhost:3000/")
 @RequestMapping("/user")
@@ -94,10 +96,12 @@ public class UserController {
     @PatchMapping("/leave")
     public ResponseEntity<String> deleteUser(Authentication authentication){
         String id = authentication.getName();
+//        String id  = userService.getUserId(authentication);
         User user = userService.findbyId(id);
-        user.updateUserStatus(false);
+//        user.updateUserStatus(false);
+        userService.updateUserStatus(user);
         //구독삭제도 추가하기
         subscribeService.deleteByUser(user);
-        return ResponseEntity.status(HttpStatus.OK).body(id + "휴면계정되었습니다");
+        return ResponseEntity.status(HttpStatus.OK).body(id + " 휴면계정되었습니다");
     }
 }

--- a/backend/src/main/java/com/haedal/backend/auth/model/User.java
+++ b/backend/src/main/java/com/haedal/backend/auth/model/User.java
@@ -87,4 +87,6 @@ public class User {
         this.userId = userId;
         this.id = id;
     }
+
+
 }

--- a/backend/src/main/java/com/haedal/backend/auth/service/UserService.java
+++ b/backend/src/main/java/com/haedal/backend/auth/service/UserService.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -86,4 +87,14 @@ public class UserService {
         userRepository.deleteById(id);
     }
 
+
+    public String getUserId(Authentication authentication)
+    {
+        return authentication.getName();
+    }
+
+    public void updateUserStatus(User user)
+    {
+        user.updateUserStatus(false);
+    }
 }

--- a/backend/src/test/java/com/haedal/backend/auth/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/haedal/backend/auth/controller/UserControllerTest.java
@@ -15,23 +15,31 @@ import com.haedal.backend.auth.model.User;
 import com.haedal.backend.common.ControllerTest;
 import com.haedal.backend.profile.model.ServicePurpose;
 import com.haedal.backend.profile.model.UserAgeGroup;
+import com.haedal.backend.subscribe.model.Subscribe;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.operation.preprocess.Preprocessors;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.test.context.support.WithSecurityContextTestExecutionListener;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import java.nio.charset.StandardCharsets;
 
+import javax.transaction.Transactional;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 
 class UserControllerTest extends ControllerTest {
@@ -156,45 +164,46 @@ class UserControllerTest extends ControllerTest {
     }
 
 
-//    @DisplayName("회원탈퇴 - 휴면계정으로 변환")
-//    @Test
-//    @WithMockUser(username = "testUserId",roles = "USER")
-//    public void testDeleteUser() throws Exception {
-//        // 사용자 ID와 User 객체 생성
-//
-//        String id = "testUserId";
-//        User user = new User(1L, "testUserId");
-//
-//        // userService.findbyId() 메서드가 호출될 때 예상 결과 설정
-//        when(userService.findbyId(id)).thenReturn(user);
-//
-//        // 로그인 유저 설정(withMockUser로 대체) 로그인 후 토큰 발급 처리를 미리 설정해주어야할듯
-//
-//        // MockMvc를 사용하여 컨트롤러 엔드포인트 호출
-//        Authentication authentication = mock(Authentication.class);
-//        when(authentication.getName()).thenReturn(id);
-//
-//        // SecurityContextHolder에 설정
-//        SecurityContextHolder.getContext().setAuthentication(authentication);
-//
-//
-//
-//        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.patch("/user/leave")
-//                .with(csrf())
-//                .with(authentication(authentication))
-//                .contentType(MediaType.APPLICATION_JSON));
-//
-//        // 테스트 결과 검증
-//        result.andExpect(status().isOk())
-//                .andExpect(content().string(id + "휴면계정되었습니다"));
-//
-//        // userService.findbyId()가 한 번 호출되었는지 확인
-//        verify(userService, times(1)).findbyId(id);
-//
-//        // user.updateUserStatus()와 subscribeService.deleteByUser()가 각각 한 번 호출되었는지 확인
-//        verify(user, times(1)).updateUserStatus(false);
-//        verify(subscribeService, times(1)).deleteByUser(user);
-//    }
+    @DisplayName("회원탈퇴 - 휴면계정으로 변환")
+    @Test
+
+    public void testDeleteUser() throws Exception {
+        // 가상 사용자 정보 생성
+        String username = "testuser";
+        Authentication authentication =new TestingAuthenticationToken(username, null,"ROLE_USER");
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        // userService.getUserId() 메서드의 Mock 설정
+        given(userService.getUserId(authentication)).willReturn(username);
+
+        // userService.findbyId() 메서드의 Mock 설정
+//        User user = new User(1L,username);
+//        List<Subscribe> subscribeList =;
+
+        User user = User.builder().userId(1L).id(username).password("1234").userStatus(true).build();
+        given(userService.findbyId(username)).willReturn(user);
+
+        // 컨트롤러 호출
+        mockMvc.perform(MockMvcRequestBuilders.patch("/user/leave")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authentication)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string(username + " 휴면계정되었습니다"));
+
+        // userService.updateUserStatus() 및 subscribeService.deleteByUser() 메서드 호출 여부 검증
+        verify(userService, times(1)).updateUserStatus(user);
+        verify(subscribeService, times(1)).deleteByUser(user);
+    }
+
 }
+
+
+
+
+
+
+
+
 
 

--- a/backend/src/test/java/com/haedal/backend/common/ControllerTest.java
+++ b/backend/src/test/java/com/haedal/backend/common/ControllerTest.java
@@ -22,7 +22,7 @@ import org.springframework.data.jpa.util.JpaMetamodel;
 @WebMvcTest({
         UserController.class
 })
-@TestPropertySource(properties = "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration")
+//@TestPropertySource(properties = "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration")
 public abstract class ControllerTest {
     @Autowired
     protected MockMvc mockMvc;


### PR DESCRIPTION
Authentication 이 security를 사용하는 기능이기때문에 공통적으로 security를 해제하는 메서드 삭제,
권한이 필요없을때는 @withmockuser로 처리, with(csrf(())를 사용하여 security csrf체크 통과시켜준다